### PR TITLE
Change repository to eu.gcr.io

### DIFF
--- a/.github/workflows/cloudrun.yml
+++ b/.github/workflows/cloudrun.yml
@@ -29,7 +29,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: "gcr.io/${{ secrets.GCP_PROJECT_ID }}/cts"
+          images: "eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/cts"
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -45,7 +45,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: "type=registry,ref=gcr.io/${{ secrets.GCP_PROJECT_ID }}/cts"
+          cache-from: "type=registry,ref=eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/cts"
           cache-to: type=inline
 
       - name: Deploy to Cloud Run
@@ -53,10 +53,10 @@ jobs:
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: cts
-          image: gcr.io/${{ secrets.GCP_PROJECT_ID }}/cts
+          image: eu.gcr.io/${{ secrets.GCP_PROJECT_ID }}/cts
           region: europe-west3
           flags: "--allow-unauthenticated"
 
       - name: Output
-        run: curl ${{ steps.deploy.outputs.url }}/ping
+        run: curl -i ${{ steps.deploy.outputs.url }}/ping
 


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration for deploying to Cloud Run. The changes update the registry references and improve the deployment output.

Changes to Cloud Run deployment workflow:

* [`.github/workflows/cloudrun.yml`](diffhunk://#diff-3b2f065c65843fbc79500b80fe96f5e3616a5d9ef6c5592b0cb04af7c8ee3cd5L48-R61): Updated `cache-from` and `image` references to use the European registry (`eu.gcr.io`).
* [`.github/workflows/cloudrun.yml`](diffhunk://#diff-3b2f065c65843fbc79500b80fe96f5e3616a5d9ef6c5592b0cb04af7c8ee3cd5L48-R61): Modified the `Output` step to include headers in the `curl` command by adding the `-i` flag.